### PR TITLE
Add kubelogin devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
         features:
           - color
           - hello
+          - kubelogin
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -34,6 +35,7 @@ jobs:
         features:
           - color
           - hello
+          - kubelogin
     steps:
       - uses: actions/checkout@v3
 

--- a/src/kubelogin/devcontainer-feature.json
+++ b/src/kubelogin/devcontainer-feature.json
@@ -1,0 +1,17 @@
+{
+    "id": "kubelogin",
+    "name": "kubelogin",
+    "version": "1.0.0",
+    "description": "Installs latest version of kubelogin, or an earlier version if specified.  Only works on Debian/Ubuntu.",
+    "documentationURL": "https://github.com/agilepathway/features/tree/main/src/kubelogin",
+    "options": {
+      "version": {
+        "type": "string",
+        "proposals": [
+          "latest"
+        ],
+        "default": "latest",
+        "description": "Select or enter a version."
+      }
+    }
+  }

--- a/src/kubelogin/install.sh
+++ b/src/kubelogin/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+KUBELOGIN_VERSION="${VERSION:-"latest"}"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+	exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+architecture="$(uname -m)"
+case ${architecture} in
+"Darwin x86_64") architecture="darwin-amd64" ;;
+"Darwin arm64") architecture="darwin-arm64" ;;
+x86_64) architecture="linux-amd64" ;;
+aarch64) architecture="linux-arm64" ;;
+*)
+	echo "(!) Architecture ${architecture} unsupported"
+	exit 1
+	;;
+esac
+
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+	if ! dpkg -s "$@" >/dev/null 2>&1; then
+		if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+			echo "Running apt-get update..."
+			apt-get update -y
+		fi
+		apt-get -y install --no-install-recommends "$@"
+	fi
+}
+
+# make sure we have curl
+check_packages ca-certificates curl
+
+github_repo_uri=https://github.com/Azure/kubelogin
+if [ "${KUBELOGIN_VERSION}" == "latest" ]; then
+	kubelogin_uri="$github_repo_uri/releases/latest/download/kubelogin-${architecture}.zip"
+else
+	kubelogin_uri="$github_repo_uri/releases/download/v${KUBELOGIN_VERSION}/kubelogin-${architecture}.zip"
+fi
+
+kubelogin_install="/usr/local/lib/kubelogin"
+# the architecture dir in the zip has _ not -
+bin_architecture_dir=${architecture/-/_}
+bin_dir="$kubelogin_install/bin/$bin_architecture_dir"
+zip="$kubelogin_install/kubelogin.zip"
+exe="$bin_dir/kubelogin"
+
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
+fi
+
+check_packages unzip
+
+curl --fail --location --progress-bar --output $zip "$kubelogin_uri"
+unzip -d $kubelogin_install -o $zip
+chmod +x "$exe"
+rm $zip
+
+ln -s "$exe" /usr/local/bin/kubelogin
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/test/kubelogin/scenarios.json
+++ b/test/kubelogin/scenarios.json
@@ -1,0 +1,10 @@
+{
+    "specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "kubelogin": {
+                "version": "0.0.26"
+            }
+        }
+    }
+}

--- a/test/kubelogin/specific_version.sh
+++ b/test/kubelogin/specific_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+specified_version_in_scenarios_json=0.0.26
+check "verify specified version installed" bash -c "kubelogin --version | grep $specified_version_in_scenarios_json"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/kubelogin/test.sh
+++ b/test/kubelogin/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'kubelogin' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "kubelogin": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in the
+# Feature's 'devcontainer-feature.json'.
+# For the 'kubelogin' feature, that means the version is 'latest'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+# 
+# This test can be run with the following command:
+#
+#    devcontainer features test      \ 
+#               --features kubelogin \
+#               --remote-user root   \
+#               --skip-scenarios     \
+#               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#               /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+check "validate kubelogin install" kubelogin --version
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
[kubelogin][1] provides azure authentication features that are not available in [kubectl][2].

The devcontainer feature installs the latest version of kubelogin by default, or a specific version can be specified. The feature works on debian/ubuntu.

[1]: https://github.com/Azure/kubelogin
[2]: https://kubernetes.io/docs/reference/kubectl/