### PR TITLE
Add YAML linting CI checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
+---
 name: "Release dev container features & Generate Documentation"
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
@@ -19,7 +20,7 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./src"
           generate-docs: "true"
-          
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,6 +10,7 @@ on:  # yamllint disable-line rule:truthy
   push:
 
 jobs:
+
   shellcheck:
     name: runner / shellcheck
     runs-on: ubuntu-latest
@@ -23,3 +24,14 @@ jobs:
           path: "."
           pattern: "*.sh"
           exclude: "./.git/*"
+
+  yamllint:
+    name: runner / yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: yamllint
+        uses: reviewdog/action-yamllint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,6 @@
+---
 name: "CI - Test Features"
-on:
+on:  # yamllint disable-line rule:truthy
   push:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,6 @@
+---
 name: "Validate devcontainer-feature.json files"
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   pull_request:
 

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 120 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
Use the [reviewdog yamllint GitHub Action][1] to lint YAML files using
[yamllint][2], on every push and pull request.
    
[1]: https://github.com/reviewdog/action-yamllint
[2]: https://github.com/adrienverge/yamllint