### PR TITLE
Add Prism devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         features:
           - kubelogin
+          - prism
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -33,6 +34,7 @@ jobs:
       matrix:
         features:
           - kubelogin
+          - prism
     steps:
       - uses: actions/checkout@v3
 

--- a/src/prism/devcontainer-feature.json
+++ b/src/prism/devcontainer-feature.json
@@ -1,0 +1,17 @@
+{
+    "id": "prism",
+    "name": "prism",
+    "version": "1.0.0",
+    "description": "Installs latest version of prism (https://stoplight.io/open-source/prism), or an earlier version if specified.  Only works on Debian/Ubuntu.",
+    "documentationURL": "https://github.com/agilepathway/features/tree/main/src/prism",
+    "options": {
+      "version": {
+        "type": "string",
+        "proposals": [
+          "latest"
+        ],
+        "default": "latest",
+        "description": "Select or enter a version."
+      }
+    }
+  }

--- a/src/prism/install.sh
+++ b/src/prism/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+PRISM_VERSION="${VERSION:-"latest"}"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+	exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+architecture="$(uname -m)"
+case ${architecture} in
+"Darwin x86_64" | "Darwin arm64") architecture="macos" ;;
+x86_64 | aarch64) architecture="linux" ;;
+*)
+	echo "(!) Architecture ${architecture} unsupported"
+	exit 1
+	;;
+esac
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+	if ! dpkg -s "$@" >/dev/null 2>&1; then
+		if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+			echo "Running apt-get update..."
+			apt-get update -y
+		fi
+		apt-get -y install --no-install-recommends "$@"
+	fi
+}
+
+# make sure we have curl
+check_packages ca-certificates curl
+
+github_repo_uri=https://github.com/stoplightio/prism
+if [ "${PRISM_VERSION}" == "latest" ]; then
+	prism_uri="$github_repo_uri/releases/latest/download/prism-cli-${architecture}"
+else
+	prism_uri="$github_repo_uri/releases/download/v${PRISM_VERSION}/prism-cli-${architecture}"
+fi
+
+prism_install_dir="/usr/local/lib/prism"
+exe="$prism_install_dir/prism"
+
+if [ ! -d "$prism_install_dir" ]; then
+	mkdir -p "$prism_install_dir"
+fi
+
+curl --fail --location --progress-bar --output "$exe" "$prism_uri"
+chmod +x "$exe"
+
+ln -s "$exe" /usr/local/bin/prism
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/test/prism/scenarios.json
+++ b/test/prism/scenarios.json
@@ -1,0 +1,10 @@
+{
+    "specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "prism": {
+                "version": "4.10.6"
+            }
+        }
+    }
+}

--- a/test/prism/specific_version.sh
+++ b/test/prism/specific_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+specified_version_in_scenarios_json=4.10.6
+check "verify specified version installed" bash -c "prism --version | grep $specified_version_in_scenarios_json"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/prism/test.sh
+++ b/test/prism/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'prism' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "prism": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in the
+# Feature's 'devcontainer-feature.json'.
+# For the 'prism' feature, that means the version is 'latest'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+# 
+# This test can be run with the following command:
+#
+#    devcontainer features test      \ 
+#               --features prism \
+#               --remote-user root   \
+#               --skip-scenarios     \
+#               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#               /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+check "validate prism install" prism --version
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
[Prism][1] is an open-source HTTP Mock and Proxy Server, powered by OpenAPI documents.

The devcontainer feature installs the latest version of Prism by default, or a specific version can be specified. The feature works on debian/ubuntu.

[1]: https://stoplight.io/open-source/prism