### PR TITLE
Fix Prism installation on ARM64

### DIFF
--- a/src/prism/NOTES.md
+++ b/src/prism/NOTES.md
@@ -1,0 +1,9 @@
+## OS Support
+
+This Feature should work on recent `x86_64`/`amd64` or `aarch64`/`arm64` versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+If `aarch64`/`arm64` then the Feature will install node and npm if they are not already on the devcontainer (as they are needed
+for `aarch64`/`arm64` Prism installs).
+
+`bash` is required to execute the `install.sh` script.
+

--- a/src/prism/devcontainer-feature.json
+++ b/src/prism/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "id": "prism",
     "name": "prism",
-    "version": "1.0.0",
-    "description": "Installs latest version of prism (https://stoplight.io/open-source/prism), or an earlier version if specified.  Only works on Debian/Ubuntu.",
+    "version": "1.0.1",
+    "description": "Installs [Prism](https://stoplight.io/open-source/prism)",
     "documentationURL": "https://github.com/agilepathway/features/tree/main/src/prism",
     "options": {
       "version": {

--- a/test/prism/latest_version_with_node_already_installed.sh
+++ b/test/prism/latest_version_with_node_already_installed.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "validate prism install on container that already has node installed" prism --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/prism/scenarios.json
+++ b/test/prism/scenarios.json
@@ -6,5 +6,19 @@
                 "version": "4.10.6"
             }
         }
+    },
+    "specific_version_with_node_already_installed": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node",
+        "features": {
+            "prism": {
+                "version": "4.10.6"
+            }
+        }
+    },
+    "latest_version_with_node_already_installed": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node",
+        "features": {
+            "prism": {}
+        }
     }
 }

--- a/test/prism/specific_version_with_node_already_installed.sh
+++ b/test/prism/specific_version_with_node_already_installed.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+specified_version_in_scenarios_json=4.10.6
+check "verify specified version installed" bash -c "prism --version | grep $specified_version_in_scenarios_json"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
Prior to this commit the Prism feature was failing to install Prism on
ARM64 (e.g. when the host machine was a Mac with an M1 or M2 chip). This
is because [currently the Prism maintainers do not currently publish an
ARM64 binary as part of their release process][1].  The fix in this
commit is to fallback to installing via npm if on ARM64.
    
To facilitate this the feature now installs node and npm if they are not
already installed on the container.  In theory we could ensure the
feature is completely idempotent by packaging a binary and then
uninstalling node and npm if they were installed by the feature, but
that would be overkill for now at least.  We can always do this in a
future PR if there is a need for it.

[1]: https://github.com/stoplightio/prism/issues/2055