### PR TITLE
Add Gauge devcontainer feature

### DIFF
--- a/.github/workflows/test-arm64.yaml
+++ b/.github/workflows/test-arm64.yaml
@@ -19,6 +19,7 @@ jobs:
         features:
           - kubelogin
           - prism
+          - gauge
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -40,6 +41,7 @@ jobs:
         features:
           - kubelogin
           - prism
+          - gauge
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ jobs:
         features:
           - kubelogin
           - prism
+          - gauge
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -35,6 +36,7 @@ jobs:
         features:
           - kubelogin
           - prism
+          - gauge
     steps:
       - uses: actions/checkout@v3
 

--- a/src/gauge/NOTES.md
+++ b/src/gauge/NOTES.md
@@ -1,0 +1,6 @@
+## OS Support
+
+This Feature should work on recent `x86_64`/`amd64` or `aarch64`/`arm64` versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+

--- a/src/gauge/devcontainer-feature.json
+++ b/src/gauge/devcontainer-feature.json
@@ -12,6 +12,19 @@
         ],
         "default": "latest",
         "description": "Select or enter a version."
+      },
+      "language": {
+        "type": "string",
+        "enum": [
+          "none",
+          "csharp",
+          "java",
+          "js",
+          "python",
+          "ruby"
+        ],
+        "default": "none",
+        "description": "Select a language plugin to install."
       }
     }
   }

--- a/src/gauge/devcontainer-feature.json
+++ b/src/gauge/devcontainer-feature.json
@@ -1,0 +1,17 @@
+{
+    "id": "gauge",
+    "name": "gauge",
+    "version": "1.0.0",
+    "description": "Installs [Gauge](https://gauge.org), a test automation framework that takes the pain out of acceptance testing",
+    "documentationURL": "https://github.com/agilepathway/features/tree/main/src/gauge",
+    "options": {
+      "version": {
+        "type": "string",
+        "proposals": [
+          "latest"
+        ],
+        "default": "latest",
+        "description": "Select or enter a version."
+      }
+    }
+  }

--- a/src/gauge/install.sh
+++ b/src/gauge/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 GAUGE_VERSION="${VERSION:-"latest"}"
+LANGUAGE="${LANGUAGE:-"none"}"
 
 set -e
 
@@ -61,6 +62,11 @@ chmod +x "$exe"
 rm $zip
 
 ln -s "$exe" /usr/local/bin/gauge
+
+
+if [ "${LANGUAGE}" != "none" ]; then
+	su "${_REMOTE_USER}" -c "gauge install $LANGUAGE"
+fi
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/src/gauge/install.sh
+++ b/src/gauge/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+GAUGE_VERSION="${VERSION:-"latest"}"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+	exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+architecture="$(uname -m)"
+case ${architecture} in
+x86_64) architecture="x86_64";;
+aarch64 | armv8*) architecture="arm64";;
+*)
+	echo "(!) Architecture ${architecture} unsupported"
+	exit 1
+	;;
+esac
+
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+	if ! dpkg -s "$@" >/dev/null 2>&1; then
+		if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+			echo "Running apt-get update..."
+			apt-get update -y
+		fi
+		apt-get -y install --no-install-recommends "$@"
+	fi
+}
+
+# make sure we have curl
+check_packages ca-certificates curl
+
+if [ "${GAUGE_VERSION}" = "latest" ]; then
+    GAUGE_VERSION=$(curl -s https://api.github.com/repos/getgauge/gauge/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
+	export GAUGE_VERSION
+fi
+
+github_repo_uri=https://github.com/getgauge/gauge
+gauge_uri="$github_repo_uri/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.${architecture}.zip"
+
+gauge_install="/usr/local/lib/gauge"
+zip="$gauge_install/gauge.zip"
+exe="$gauge_install/gauge"
+
+if [ ! -d "$gauge_install" ]; then
+	mkdir -p "$gauge_install"
+fi
+
+check_packages unzip
+
+curl --fail --location --progress-bar --output $zip "$gauge_uri"
+unzip -d $gauge_install -o $zip
+chmod +x "$exe"
+rm $zip
+
+ln -s "$exe" /usr/local/bin/gauge
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/test/gauge/csharp-latest.sh
+++ b/test/gauge/csharp-latest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "csharp plugin latest version installed" gauge --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/java-latest.sh
+++ b/test/gauge/java-latest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "java plugin latest version installed" gauge --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/js-latest.sh
+++ b/test/gauge/js-latest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "js plugin latest version installed" gauge --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/python-latest.sh
+++ b/test/gauge/python-latest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "python plugin latest version installed" gauge --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/ruby-latest.sh
+++ b/test/gauge/ruby-latest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "ruby plugin latest version installed" gauge --version
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/scenarios.json
+++ b/test/gauge/scenarios.json
@@ -1,0 +1,10 @@
+{
+    "specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gauge": {
+                "version": "1.4.2"
+            }
+        }
+    }
+}

--- a/test/gauge/scenarios.json
+++ b/test/gauge/scenarios.json
@@ -6,5 +6,46 @@
                 "version": "1.4.2"
             }
         }
+    },
+    "csharp-latest": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gauge": {
+                "language": "csharp"
+            }
+        }
+    },
+    "java-latest": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gauge": {
+                "language": "java"
+            }
+        }
+    },
+    "js-latest": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node",
+        "features": {
+            "gauge": {
+                "language": "js"
+            }
+        }
+    },
+    "python-latest": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gauge": {
+                "language": "python"
+            }
+        }
+    },
+    "ruby-latest": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gauge": {
+                "language": "ruby"
+            }
+        }
     }
+
 }

--- a/test/gauge/specific_version.sh
+++ b/test/gauge/specific_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+specified_version_in_scenarios_json=1.4.2
+check "verify specified version installed" bash -c "gauge --version | grep $specified_version_in_scenarios_json"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/gauge/test.sh
+++ b/test/gauge/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'gauge' Feature with no options.
+#
+# For more information, see: https://github.com/devcontainers/cli/blob/main/docs/features/test.md
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "gauge": {}
+#    },
+#    "remoteUser": "root"
+# }
+#
+# Thus, the value of all options will fall back to the default value in the
+# Feature's 'devcontainer-feature.json'.
+# For the 'gauge' feature, that means the version is 'latest'.
+#
+# These scripts are run as 'root' by default. Although that can be changed
+# with the '--remote-user' flag.
+# 
+# This test can be run with the following command:
+#
+#    devcontainer features test      \ 
+#               --features gauge \
+#               --remote-user root   \
+#               --skip-scenarios     \
+#               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#               /path/to/this/repo
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+check "validate gauge install" gauge --version
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
* Add Gauge devcontainer feature

  [Gauge][1] is a test automation framework that takes the pain out of
  acceptance testing.
    
  The devcontainer feature installs the latest version of Gauge by
  default, or a specific version can be specified. The feature works on
  debian/ubuntu.

* Add option to install Gauge language plugin

  [Gauge language plugins documentation][2]


[1]: https://gauge.org
[2]: https://gauge.org/plugins/#language